### PR TITLE
RGS Motor 13 Demo Update

### DIFF
--- a/main.c
+++ b/main.c
@@ -9,11 +9,11 @@
 
 int main()
 {
-	init_rgs13_timer0();
+	init_rgs13_timer1();
 
 	while(1)
 	{
-		update_rgs13_timer0();
+		update_rgs13_timer1();
 	}
 	return 0;
 }

--- a/rgs13.h
+++ b/rgs13.h
@@ -11,13 +11,18 @@
 //#define F_CPU 16000000UL
 #include <util/delay.h>
 
-#define RGS_MAX_8BIT	75
-#define RGS_MIN_8BIT	20
-#define T_MS		150
+//#define RGS_MAX_T0	75
+//#define RGS_MIN_T0	20
+#define RGS_MAX_T1	300
+#define RGS_MIN_T1	80
+#define T_MS		50
 
-volatile uint8_t counter_8bit = RGS_MIN_8BIT;
-volatile uint8_t flag_8bit = 0;
+//volatile uint8_t counter_timer0 = RGS_MIN_T0;
+//volatile uint8_t flag_timer0 = 0;
+volatile uint16_t counter_timer1 = RGS_MIN_T1;
+volatile uint8_t flag_timer1 = 0;
 
+/*
 void init_rgs13_timer0()
 {
 	DDRD = (1 << DDD6)|(1 << DDD5);
@@ -27,24 +32,37 @@ void init_rgs13_timer0()
 }
 void update_rgs13_timer0()
 {
-	OCR0B = counter_8bit;
+	OCR0B = counter_timer0;
         _delay_ms(T_MS);
-        if(counter_8bit > RGS_MAX_8BIT)
-                flag_8bit = 0;
-        else if (counter_8bit < RGS_MIN_8BIT)
-                flag_8bit = 1;
-        if(flag_8bit == 1)
-                counter_8bit++;
+        if(counter_timer0 > RGS_MAX_T0)
+                flag_timer0 = 0;
+        else if (counter_timer0 < RGS_MIN_T0)
+                flag_timer0 = 1;
+        if(flag_timer0 == 1)
+                counter_timer0++;
         else
-        	counter_8bit--;
+        	counter_timer0--;
 
 }
+*/
 
 void init_rgs13_timer1() /* TODO: ADD CODE TAHT CREATES 16-BIT FUNCTIONALITY TO THE MOTOR*/
 {
-	
+	DDRB = (1 << DDB2)|(1 << DDB1);
+        TCCR1A = (1 << COM1A1)|(0 << COM1A0)|(1 << COM1B1)|(0 << COM1B0)|(1 << WGM11)|(1 << WGM10);
+        TCCR1B = (0 << CS12)|(1 << CS11)|(1 << CS10);
+        OCR1A = 1023;
 }
 void update_rgs13_timer1()
 {
-	
+	OCR1B = counter_timer1;
+        _delay_ms(T_MS);
+        if(counter_timer1 > RGS_MAX_T1)
+                flag_timer1 = 0;
+        else if (counter_timer1 < RGS_MIN_T1)
+                flag_timer1 = 1;
+        if(flag_timer1 == 1)
+                counter_timer1++;
+        else
+                counter_timer1--;
 }


### PR DESCRIPTION
Changed the labels of the timers from 8-bit to just calling it Timer0 since Timer0 is an 8-bit timer essentially.

The major change though is adding support for Timer1, which is a 16-bit timer that is running in 10-Bit Phase Correct mode.